### PR TITLE
Set a help message.

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -268,13 +268,12 @@ async def check_for_deposit():
 
 @client.event
 async def on_ready():
-
-    print('Logged in as')
-    print(client.user.name)
-    print(client.user.id)
-    print('------')
-
     logger.info('connected as %s and id %s', client.user.name, client.user.id)
+
+    # Let users know we're watching for commands by setting the bot's activity.
+    watching = discord.Activity(type=discord.ActivityType.watching, name='DM me "$help".')
+    await bot.change_presence(activity=watching)
+
     asyncio.get_event_loop().create_task(check_for_deposit())
 
 

--- a/src/db.py
+++ b/src/db.py
@@ -8,7 +8,7 @@ from peewee import (SqliteDatabase,
                     DateField
 )
 
-from conf import DB_NAME
+from .conf import DB_NAME
 
 db = SqliteDatabase(DB_NAME)
 

--- a/src/wallet.py
+++ b/src/wallet.py
@@ -1,13 +1,13 @@
 from bitcoinrpc.authproxy import AuthServiceProxy
 
-import util
-import db
+from . import util
+from . import db
 import datetime
 import logging
-from conf import (RPC_PORT,
-                  RPC_USER,
-                  RPC_PASSWORD,
-                  RPC_HOST
+from .conf import (RPC_PORT,
+                   RPC_USER,
+                   RPC_PASSWORD,
+                   RPC_HOST
 )
 
 logging.basicConfig(filename='bot.log', level=logging.INFO)


### PR DESCRIPTION
Discord users don't always know how to use the tippbot. We might be able to bridge the gap by setting the bot's activity message to a hint about how to start communicating with it :robot: