### PR TITLE
Check that the user has enough funds to withdraw desired amount.

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -170,6 +170,8 @@ def setup_bot():
                                       "You do not have a minimum of 0.01 PPC !",
                                       "Minimum withdraw amount is 0.01 PPC !",
                                       "Uh I'm sorry :sweat: ... Minimum withdrawal amount is 0.01 PPC"
+                                  ], "insufficient_funds": [
+                                      "You don't have enough coins to withdraw that much :scream: :scream: "
                                   ]})
 
     top_feature = BotFeature(command="TOP",
@@ -347,6 +349,8 @@ async def on_message(message):
                     post_response(message, feat.response_templates["address_not_found"])
                 if e.error_type == "error":
                     post_response(message, feat.response_templates["error"])
+                if e.error_type == "insufficient_funds":
+                    post_response(message, feat.response_templates["insufficient_funds"])
     except socket_error as serr:
         if serr.errno != errno.ECONNREFUSED:
             raise serr

--- a/src/wallet.py
+++ b/src/wallet.py
@@ -54,6 +54,8 @@ def get_balance(user_id: int) -> float:
 
 
 def make_transaction_to_address(user, amount, address):
+    if not check_balance(user_id, amount):
+        raise util.TipBotException("insufficient_funds")
 
     rpc_connection = connect()
 


### PR DESCRIPTION
We need to make sure the user has enough money to actually withdraw.

Without this check a user with 0 balance could withdraw 1000 peercoins, receive the coins and have an internal account balance of -1000. Probably not the desired behavior.